### PR TITLE
Make sure that looking up an error document uses the correct error code

### DIFF
--- a/src/App/src/Content/ErrorDocumentLocator.php
+++ b/src/App/src/Content/ErrorDocumentLocator.php
@@ -40,6 +40,11 @@ class ErrorDocumentLocator
         }
     }
 
+    public function hasCode(int $code) : bool
+    {
+        return isset($this->map[$code]);
+    }
+
     public function byCode(int $code) : Document
     {
         $locator = $this->map[$code] ?? null;

--- a/src/App/src/Middleware/ErrorResponseGenerator.php
+++ b/src/App/src/Middleware/ErrorResponseGenerator.php
@@ -41,7 +41,8 @@ class ErrorResponseGenerator
         $status = Utils::getStatusCode($e, $response);
         $response = $response->withStatus($status);
         try {
-            $response->getBody()->write($this->generateErrorContent($status));
+            $code = $this->locator->hasCode($e->getCode()) ? $e->getCode() : $status;
+            $response->getBody()->write($this->generateErrorContent($code));
 
             return $response;
         } catch (Throwable $error) {
@@ -49,7 +50,7 @@ class ErrorResponseGenerator
         }
     }
 
-    private function generateErrorContent(int $code = 500) : string
+    private function generateErrorContent(int $code) : string
     {
         $document = $this->locator->byCode($code);
         $this->renderer->addDefaultParam(

--- a/test/Integration/EndpointTest.php
+++ b/test/Integration/EndpointTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace AppTest\Integration;
 
 use AppTest\Integration\Framework\TestCase;
-use Laminas\Diactoros\ServerRequestFactory;
 use Prismic\ApiClient;
 use Prismic\Document;
 use Prismic\LinkResolver;

--- a/test/Integration/EndpointTest.php
+++ b/test/Integration/EndpointTest.php
@@ -28,7 +28,7 @@ class EndpointTest extends TestCase
 
     public function testHomePageIsAccessible() : void
     {
-        $request = (new ServerRequestFactory())->createServerRequest('GET', '/');
+        $request = $this->serverRequest('/');
         $response = $this->handle($request);
         self::assertResponseHasStatus($response, 200);
     }
@@ -43,21 +43,21 @@ class EndpointTest extends TestCase
         $url = $linkResolver->resolve($document->asLink());
         $this->assertNotNull($url, 'No url could be constructed for the given document');
 
-        $request = (new ServerRequestFactory())->createServerRequest('GET', $url);
+        $request = $this->serverRequest($url);
         $response = $this->handle($request);
         self::assertResponseHasStatus($response, 200);
     }
 
     public function testNotFound() : void
     {
-        $request = (new ServerRequestFactory())->createServerRequest('GET', '/' . uniqid('not_found', false));
+        $request = $this->serverRequest('/' . uniqid('not_found', false));
         $response = $this->handle($request);
         self::assertResponseHasStatus($response, 404);
     }
 
     public function testException() : void
     {
-        $request = (new ServerRequestFactory())->createServerRequest('GET', '/exceptional');
+        $request = $this->serverRequest('/exceptional');
         $response = $this->handle($request);
         self::assertResponseHasStatus($response, 500);
     }

--- a/test/Unit/Framework/TestCase.php
+++ b/test/Unit/Framework/TestCase.php
@@ -4,9 +4,16 @@ declare(strict_types=1);
 namespace AppTest\Unit\Framework;
 
 use Helmich\Psr7Assert\Psr7Assertions;
+use Laminas\Diactoros\ServerRequest;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+use Psr\Http\Message\ServerRequestInterface;
 
 class TestCase extends PHPUnitTestCase
 {
     use Psr7Assertions;
+
+    protected function serverRequest(string $path, string $method = 'GET') : ServerRequestInterface
+    {
+        return new ServerRequest([], [], $path, $method);
+    }
 }

--- a/test/Unit/Middleware/ErrorResponseGeneratorTest.php
+++ b/test/Unit/Middleware/ErrorResponseGeneratorTest.php
@@ -1,0 +1,176 @@
+<?php
+declare(strict_types=1);
+
+namespace AppTest\Unit\Middleware;
+
+use App\Content\ErrorDocumentLocator;
+use App\Middleware\ErrorResponseGenerator;
+use AppTest\Unit\Framework\TestCase;
+use Exception;
+use Laminas\Diactoros\Response\TextResponse;
+use Mezzio\Template\TemplateRendererInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Prismic\Document;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+
+class ErrorResponseGeneratorTest extends TestCase
+{
+    /** @var ErrorDocumentLocator|MockObject */
+    private $documentLocator;
+    /** @var TemplateRendererInterface|MockObject */
+    private $renderer;
+
+    protected function setUp() : void
+    {
+        parent::setUp();
+        $this->documentLocator = $this->createMock(ErrorDocumentLocator::class);
+        $this->renderer = $this->createMock(TemplateRendererInterface::class);
+    }
+
+    private function renderExpectsDocument(Document $document) : void
+    {
+        $this->renderer->expects($this->once())
+            ->method('addDefaultParam')
+            ->with(TemplateRendererInterface::TEMPLATE_ALL, 'document', $document);
+    }
+
+    private function rendererWillRenderTemplateWith(string $templateName) : void
+    {
+        $this->renderer->expects($this->once())
+            ->method('render')
+            ->with($templateName)
+            ->willReturn('RENDERED CONTENT');
+    }
+
+    private function responseGenerator(?callable $fallback = null) : ErrorResponseGenerator
+    {
+        $fallback = $fallback ?: function () : void {
+            $this->fail('The fallback response generator was called');
+        };
+
+        return new ErrorResponseGenerator(
+            $this->renderer,
+            'template-name',
+            $this->documentLocator,
+            $fallback
+        );
+    }
+
+    /** @return int[][] */
+    public function errorCodes() : iterable
+    {
+        return [
+            'Less than 100' => [0, 500],
+            '100 Range' => [101, 500],
+            '200 Range' => [200, 500],
+            '300 Range' => [302, 500],
+            '401' => [401, 401],
+            '402' => [402, 402],
+            '404' => [404, 404],
+            '500' => [500, 500],
+            'Above 500' => [600, 500],
+        ];
+    }
+
+    /** @dataProvider errorCodes */
+    public function testThatHttpStatusCodeMatchesErrorCodeWithMatchingDocument(int $errorCode, int $expectedHttpCode) : void
+    {
+        $error = new Exception('Error', $errorCode);
+        $request = $this->serverRequest('/foo');
+        $response = new TextResponse('Content');
+        $document = $this->createMock(Document::class);
+
+        $this->documentLocator
+            ->expects($this->once())
+            ->method('hasCode')
+            ->with($errorCode)
+            ->willReturn(true);
+
+        $this->documentLocator
+            ->expects($this->once())
+            ->method('byCode')
+            ->with($errorCode)
+            ->willReturn($document);
+
+        $this->renderExpectsDocument($document);
+        $this->rendererWillRenderTemplateWith('template-name');
+
+        $generator = $this->responseGenerator();
+        $generatedResponse = $generator($error, $request, $response);
+
+        self::assertResponseHasStatus($generatedResponse, $expectedHttpCode);
+    }
+
+    /** @dataProvider errorCodes */
+    public function testExpectedHttpStatusCodeWhenTheDefaultDocumentIsUsed(int $errorCode, int $expectedHttpCode) : void
+    {
+        $error = new Exception('Error', $errorCode);
+        $request = $this->serverRequest('/foo');
+        $response = new TextResponse('Content');
+        $document = $this->createMock(Document::class);
+
+        $this->documentLocator
+            ->expects($this->once())
+            ->method('hasCode')
+            ->with($errorCode)
+            ->willReturn(false);
+
+        $this->documentLocator
+            ->expects($this->once())
+            ->method('byCode')
+            ->with($expectedHttpCode)
+            ->willReturn($document);
+
+        $this->renderExpectsDocument($document);
+        $this->rendererWillRenderTemplateWith('template-name');
+
+        $generator = $this->responseGenerator();
+        $generatedResponse = $generator($error, $request, $response);
+
+        self::assertResponseHasStatus($generatedResponse, $expectedHttpCode);
+    }
+
+    public function testThatTheFallbackGeneratorIsCalledWhenGeneratingErrorContentFails() : void
+    {
+        $error = new Exception('Error', 0);
+        $libraryError = new Exception('Whatever', 123);
+        $request = $this->serverRequest('/foo');
+        $response = new TextResponse('Content');
+        $expectedResponse = new TextResponse('Foo', 500);
+
+        $this->documentLocator
+            ->expects($this->once())
+            ->method('hasCode')
+            ->with(0)
+            ->willReturn(false);
+
+        $this->documentLocator
+            ->expects($this->once())
+            ->method('byCode')
+            ->with(500)
+            ->willThrowException($libraryError);
+
+        $fallback = function (
+            Throwable $receivedError,
+            RequestInterface $receivedRequest,
+            ResponseInterface $receivedResponse
+        ) use (
+            $error,
+            $request,
+            $expectedResponse
+        ) : ResponseInterface {
+            $this->assertSame($error, $receivedError);
+            $this->assertSame($request, $receivedRequest);
+            self::assertMessageBodyMatches($receivedResponse, $this->equalTo('Content'));
+
+            return $expectedResponse;
+        };
+
+        $generator = $this->responseGenerator($fallback);
+        $generatedResponse = $generator($error, $request, $response);
+
+        $this->assertSame($expectedResponse, $generatedResponse);
+    }
+}


### PR DESCRIPTION
Fixes #1 - alters error response generator so that it attempts to locate a document that matches the exception error code, falling back to the HTTP status code resolved by `Laminas\Stratigility\Utils::getStatusCode()` when one does not exist.